### PR TITLE
Task 7 solution

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,10 @@ import { connecti18n } from './plugins/vue-i18n';
 import store from './store/store';
 import axios from 'axios';
 
-localStorage.setItem('creds', 'YWxyZWFkeWJvcmVkOlRFU1RfUEFTU1dPUkQ=');
+localStorage.setItem(
+	'authorization_token',
+	'YWxyZWFkeWJvcmVkOlRFU1RfUEFTU1dPUkQ='
+);
 
 axios.interceptors.response.use(
 	res => res,

--- a/src/views/ProductImport/ui/CSVFileUploader.vue
+++ b/src/views/ProductImport/ui/CSVFileUploader.vue
@@ -57,7 +57,7 @@ const fetchPresignedS3Url = (url: string, fileName: string) => {
 			name: encodeURIComponent(fileName),
 		},
 		headers: {
-			Authorization: `Basic ${localStorage.getItem('creds')}`,
+			Authorization: `Basic ${localStorage.getItem('authorization_token')}`,
 		},
 	});
 };


### PR DESCRIPTION
2 things added:
1. Programmatically set key `authorization_token` (Base64-encoded string `alreadybored:TEST_PASSWORD`)
2. Added alerts on responses with 401 and 403 status code using `axios.interceptors`

[BE PR](https://github.com/AlreadyBored/shop-backend/pull/5)